### PR TITLE
Fix macOS redo shortcut

### DIFF
--- a/src/slic3r/GUI/GLCanvas3D.cpp
+++ b/src/slic3r/GUI/GLCanvas3D.cpp
@@ -3634,6 +3634,14 @@ void GLCanvas3D::on_char(wxKeyEvent& evt)
                 post_event(SimpleEvent(EVT_GLTOOLBAR_DELETE_ALL));
                 return;
             }
+            case 'z':
+            case 'Z':
+            case WXK_CONTROL_Z: {
+                if (m_canvas_type == CanvasView3D || m_canvas_type == CanvasAssembleView) {
+                    post_event(SimpleEvent(EVT_GLCANVAS_REDO));
+                }
+                return;
+            }
             }
         }
         // CTRL is pressed

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -221,6 +221,9 @@ ObjectList::ObjectList(wxWindow* parent) :
         entries[index++].Set(wxACCEL_CTRL, (int)'A', wxID_SELECTALL);
         entries[index++].Set(wxACCEL_CTRL, (int)'Z', wxID_UNDO);
         entries[index++].Set(wxACCEL_CTRL, (int)'Y', wxID_REDO);
+#ifdef __APPLE__
+        entries[index++].Set(wxACCEL_CTRL | wxACCEL_SHIFT, (int)'Z', wxID_REDO);
+#endif
         entries[index++].Set(wxACCEL_NORMAL, WXK_BACK, wxID_DELETE);
         //entries[index++].Set(wxACCEL_NORMAL, int('+'), wxID_ADD);
         //entries[index++].Set(wxACCEL_NORMAL, WXK_NUMPAD_ADD, wxID_ADD);

--- a/src/slic3r/GUI/GUI_ObjectList.cpp
+++ b/src/slic3r/GUI/GUI_ObjectList.cpp
@@ -212,7 +212,7 @@ ObjectList::ObjectList(wxWindow* parent) :
     {
         // Accelerators
         // 	wxAcceleratorEntry entries[25];
-        wxAcceleratorEntry entries[26];
+        wxAcceleratorEntry entries[27];
         int index = 0;
         entries[index++].Set(wxACCEL_CTRL, (int)'C', wxID_COPY);
         entries[index++].Set(wxACCEL_CTRL, (int)'X', wxID_CUT);
@@ -221,9 +221,7 @@ ObjectList::ObjectList(wxWindow* parent) :
         entries[index++].Set(wxACCEL_CTRL, (int)'A', wxID_SELECTALL);
         entries[index++].Set(wxACCEL_CTRL, (int)'Z', wxID_UNDO);
         entries[index++].Set(wxACCEL_CTRL, (int)'Y', wxID_REDO);
-#ifdef __APPLE__
         entries[index++].Set(wxACCEL_CTRL | wxACCEL_SHIFT, (int)'Z', wxID_REDO);
-#endif
         entries[index++].Set(wxACCEL_NORMAL, WXK_BACK, wxID_DELETE);
         //entries[index++].Set(wxACCEL_NORMAL, int('+'), wxID_ADD);
         //entries[index++].Set(wxACCEL_NORMAL, WXK_NUMPAD_ADD, wxID_ADD);
@@ -238,7 +236,7 @@ ObjectList::ObjectList(wxWindow* parent) :
             numbers_cnt++;
             // index++;
         }
-        wxAcceleratorTable accel(26, entries);
+        wxAcceleratorTable accel(27, entries);
         SetAcceleratorTable(accel);
 
         this->Bind(wxEVT_MENU, [this](wxCommandEvent &evt) { this->copy();                      }, wxID_COPY);

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -254,11 +254,8 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "A", L("Select all objects")},
             {ctrl + L("Shift+D"), L("Delete all")},
             {ctrl + "Z", L("Undo")},
-#ifdef __APPLE__
             {ctrl + "Shift+Z", L("Redo")},
-#else
             {ctrl + "Y", L("Redo")},
-#endif
             { "M", L("Gizmo move") },
             { "S", L("Gizmo scale") },
             { "R", L("Gizmo rotate") },
@@ -291,11 +288,8 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "A", L("Select all objects")},
             {ctrl + "K", L("Clone selected")},
             {ctrl + "Z", L("Undo")},
-#ifdef __APPLE__
             {ctrl + "Shift+Z", L("Redo")},
-#else
             {ctrl + "Y", L("Redo")},
-#endif
             {L("Space"), L("Select the object/part and press space to change the name")},
             {L("Mouse click"), L("Select the object/part and mouse click to change the name")},
         };

--- a/src/slic3r/GUI/KBShortcutsDialog.cpp
+++ b/src/slic3r/GUI/KBShortcutsDialog.cpp
@@ -254,7 +254,11 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "A", L("Select all objects")},
             {ctrl + L("Shift+D"), L("Delete all")},
             {ctrl + "Z", L("Undo")},
+#ifdef __APPLE__
+            {ctrl + "Shift+Z", L("Redo")},
+#else
             {ctrl + "Y", L("Redo")},
+#endif
             { "M", L("Gizmo move") },
             { "S", L("Gizmo scale") },
             { "R", L("Gizmo rotate") },
@@ -287,7 +291,11 @@ void KBShortcutsDialog::fill_shortcuts()
             {ctrl + "A", L("Select all objects")},
             {ctrl + "K", L("Clone selected")},
             {ctrl + "Z", L("Undo")},
+#ifdef __APPLE__
+            {ctrl + "Shift+Z", L("Redo")},
+#else
             {ctrl + "Y", L("Redo")},
+#endif
             {L("Space"), L("Select the object/part and press space to change the name")},
             {L("Mouse click"), L("Select the object/part and mouse click to change the name")},
         };


### PR DESCRIPTION
## Summary
- add Shift+Command+Z accelerator for redo on macOS
- show the updated shortcut in the keyboard shortcuts dialog